### PR TITLE
Admin can delete any images

### DIFF
--- a/LotteryPatentPending/.idea/deploymentTargetSelector.xml
+++ b/LotteryPatentPending/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,9 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="MainActivity">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/LotteryPatentPending/app/src/main/java/com/example/lotterypatentpending/AdminActivity.java
+++ b/LotteryPatentPending/app/src/main/java/com/example/lotterypatentpending/AdminActivity.java
@@ -165,18 +165,22 @@ public class AdminActivity extends AppCompatActivity {
                 startActivity(intent);
             });
         }
-
-        // Stubbed: Images (only if admin)
         if (btnImages != null) {
             btnImages.setOnClickListener(v -> {
                 if (!isAdmin()) {
                     showAdminDeniedToast();
                     return;
                 }
-                // TODO: open admin images screen
-                Toast.makeText(this, "Images screen not implemented yet.", Toast.LENGTH_SHORT).show();
+                // Navigate to the AdminImagesFragment
+                getSupportFragmentManager().beginTransaction()
+                        .replace(R.id.adminFragmentContainer, new AdminImagesFragment())
+                        .addToBackStack(null) // Allows user to press back
+                        .commit();
             });
         }
+
+
+
 
         // Stubbed: Remove organizers (only if admin)
         if (btnRemoveOrganizers != null) {

--- a/LotteryPatentPending/app/src/main/java/com/example/lotterypatentpending/AdminImagesAdapter.java
+++ b/LotteryPatentPending/app/src/main/java/com/example/lotterypatentpending/AdminImagesAdapter.java
@@ -1,0 +1,121 @@
+package com.example.lotterypatentpending;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.lotterypatentpending.models.Event;
+
+import java.util.List;
+
+/**
+ * Adapter for displaying event posters and titles in a RecyclerView for administrators.
+ * It handles binding event data to the views and listens for user interactions.
+ */
+public class AdminImagesAdapter extends RecyclerView.Adapter<AdminImagesAdapter.ImageViewHolder> {
+
+    /**
+     * A listener interface for handling click and long-click events on items in the RecyclerView.
+     * The hosting Fragment or Activity must implement this interface to respond to user input.
+     */
+    public interface OnImageClickListener {
+        /**
+         * Called when an image item is clicked.
+         *
+         * @param event The event object associated with the clicked item.
+         */
+        void onImageClick(Event event);
+
+        /**
+         * Called when an image item is long-clicked.
+         *
+         * @param event The event object associated with the long-clicked item.
+         */
+        void onImageLongClick(Event event);
+    }
+
+    private final List<Event> eventList;
+    private final OnImageClickListener listener;
+
+    /**
+     * Constructs the adapter.
+     *
+     * @param eventList The list of events to display.
+     * @param listener  The listener that will handle click events.
+     */
+    public AdminImagesAdapter(List<Event> eventList, OnImageClickListener listener) {
+        this.eventList = eventList;
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public ImageViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.admin_image_item, parent, false);
+        return new ImageViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ImageViewHolder holder, int position) {
+        Event event = eventList.get(position);
+        holder.bind(event, listener);
+    }
+
+    @Override
+    public int getItemCount() {
+        return eventList.size();
+    }
+
+    /**
+     * ViewHolder for an individual event image item.
+     * It holds the views for the image and event name.
+     */
+    static class ImageViewHolder extends RecyclerView.ViewHolder {
+        ImageView imageView;
+        TextView eventNameTextView;
+
+        public ImageViewHolder(@NonNull View itemView) {
+            super(itemView);
+            imageView = itemView.findViewById(R.id.imageView);
+            eventNameTextView = itemView.findViewById(R.id.eventNameTextView);
+        }
+
+        /**
+         * Binds an event's data to the views in the ViewHolder.
+         *
+         * @param event    The event to display.
+         * @param listener The listener to attach to the item view for click handling.
+         */
+        void bind(final Event event, final OnImageClickListener listener) {
+            // Set event name
+            if (event.getTitle() != null) {
+                eventNameTextView.setText(event.getTitle());
+            } else {
+                eventNameTextView.setText("Untitled Event");
+            }
+
+            // Set image
+            byte[] bytes = event.getPosterBytes();
+            if (bytes != null && bytes.length > 0) {
+                Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+                imageView.setImageBitmap(bitmap);
+            } else {
+                imageView.setImageDrawable(null);
+            }
+
+            // Set the click and long-click listeners
+            itemView.setOnClickListener(v -> listener.onImageClick(event));
+            itemView.setOnLongClickListener(v -> {
+                listener.onImageLongClick(event);
+                return true; // long click
+            });
+        }
+    }
+}

--- a/LotteryPatentPending/app/src/main/java/com/example/lotterypatentpending/AdminImagesFragment.java
+++ b/LotteryPatentPending/app/src/main/java/com/example/lotterypatentpending/AdminImagesFragment.java
@@ -1,0 +1,193 @@
+package com.example.lotterypatentpending;
+
+import android.app.AlertDialog;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.ProgressBar;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.lotterypatentpending.models.Event;
+import com.google.firebase.firestore.Blob;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A fragment that displays a grid of event posters for an administrator.
+ * It allows the admin to view posters in full screen by clicking
+ * and to delete posters by long-clicking.
+ */
+public class AdminImagesFragment extends Fragment implements AdminImagesAdapter.OnImageClickListener {
+
+    private RecyclerView recyclerView;
+    private AdminImagesAdapter adapter;
+    private List<Event> eventList;
+    private ProgressBar progressBar;
+    private FirebaseFirestore db;
+
+    /**
+     * Inflates the fragment's layout and initializes its views and data.
+     *
+     * @param inflater           The LayoutInflater object that can be used to inflate any views in the fragment.
+     * @param container          If non-null, this is the parent view that the fragment's UI should be attached to.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed from a previous saved state.
+     * @return The View for the fragment's UI.
+     */
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.admin_fragment_images, container, false);
+
+        db = FirebaseFirestore.getInstance();
+        recyclerView = view.findViewById(R.id.imagesRecyclerView);
+        progressBar = view.findViewById(R.id.progressBar);
+        eventList = new ArrayList<>();
+
+        setupRecyclerView();
+        fetchEventsWithPosters();
+
+        return view;
+    }
+
+    /**
+     * Configures the RecyclerView with a GridLayoutManager and sets up the adapter.
+     */
+    private void setupRecyclerView() {
+        recyclerView.setLayoutManager(new GridLayoutManager(getContext(), 2));
+        adapter = new AdminImagesAdapter(eventList, this);
+        recyclerView.setAdapter(adapter);
+    }
+
+    /**
+     * Handles a click on an image item. Displays the image in a full-screen dialog.
+     *
+     * @param event The event corresponding to the clicked image.
+     */
+    @Override
+    public void onImageClick(Event event) {
+        if (getContext() == null || event.getPosterBytes() == null || event.getPosterBytes().length == 0) {
+            return;
+        }
+
+        // Create a container layout to hold the ImageView and provide padding
+        FrameLayout container = new FrameLayout(getContext());
+        container.setPadding(50, 50, 50, 50);
+        ImageView fullImageView = new ImageView(getContext());
+
+        fullImageView.setAdjustViewBounds(true);
+        fullImageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+        fullImageView.setContentDescription("Full-size event poster");
+
+        // Decode the byte array and set the image
+        Bitmap bitmap = BitmapFactory.decodeByteArray(event.getPosterBytes(), 0, event.getPosterBytes().length);
+        fullImageView.setImageBitmap(bitmap);
+        container.addView(fullImageView);
+
+        // create a dialog and set the CONTAINER as its content
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        builder.setView(container); // Set the container, which has padding
+
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+
+
+    /**
+     * Handles a long-click on an image item. Shows a confirmation dialog to delete the poster.
+     *
+     * @param event The event corresponding to the long-clicked image.
+     */
+    @Override
+    public void onImageLongClick(Event event) {
+        if (getContext() == null) return;
+
+        new AlertDialog.Builder(getContext())
+                .setTitle("Delete Image")
+                .setMessage("Are you sure you want to delete the poster for '" + event.getTitle() + "'?")
+                .setPositiveButton("Delete", (dialog, which) -> {
+                    deleteImage(event);
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    /**
+     * Deletes an event's poster by setting its 'posterBlob' field to null in Firestore.
+     *
+     * @param eventToDelete The event whose poster should be deleted.
+     */
+    private void deleteImage(Event eventToDelete) {
+        if (eventToDelete.getId() == null || eventToDelete.getId().isEmpty()) {
+            Toast.makeText(getContext(), "Error: Event ID is missing.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        // To "delete" the image, we set the posterBlob field to null
+        db.collection("events").document(eventToDelete.getId())
+                .update("posterBlob", null)
+                .addOnSuccessListener(aVoid -> {
+                    Toast.makeText(getContext(), "Image deleted.", Toast.LENGTH_SHORT).show();
+                    // Remove from the local list and update the UI
+                    int position = eventList.indexOf(eventToDelete);
+                    if (position != -1) {
+                        eventList.remove(position);
+                        adapter.notifyItemRemoved(position);
+                    }
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(getContext(), "Failed to delete image: " + e.getMessage(), Toast.LENGTH_SHORT).show();
+                    Log.e("AdminImagesFragment", "Error deleting image", e);
+                });
+    }
+
+    /**
+     * Fetches all events from Firestore that have a non-null poster image.
+     */
+    private void fetchEventsWithPosters() {
+        progressBar.setVisibility(View.VISIBLE);
+
+        db.collection("events")
+                .whereNotEqualTo("posterBlob", null)
+                .get()
+                .addOnCompleteListener(task -> {
+                    progressBar.setVisibility(View.GONE);
+                    if (task.isSuccessful() && task.getResult() != null) {
+                        eventList.clear();
+                        for (QueryDocumentSnapshot document : task.getResult()) {
+                            Event event = new Event();
+                            event.setId(document.getId());
+                            event.setTitle(document.getString("title"));
+
+                            Blob posterBlob = document.getBlob("posterBlob");
+                            if (posterBlob != null) {
+                                event.setPosterBytes(posterBlob.toBytes());
+                            }
+                            eventList.add(event);
+                        }
+                        adapter.notifyDataSetChanged();
+
+                        if (eventList.isEmpty()) {
+                            Toast.makeText(getContext(), "No event posters found.", Toast.LENGTH_SHORT).show();
+                        }
+                    } else {
+                        Toast.makeText(getContext(), "Error fetching images.", Toast.LENGTH_SHORT).show();
+                        Log.e("AdminImagesFragment", "Error fetching events with posters", task.getException());
+                    }
+                });
+    }
+}

--- a/LotteryPatentPending/app/src/main/java/com/example/lotterypatentpending/helpers/SquareImageView.java
+++ b/LotteryPatentPending/app/src/main/java/com/example/lotterypatentpending/helpers/SquareImageView.java
@@ -1,0 +1,32 @@
+package com.example.lotterypatentpending.helpers;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatImageView;
+
+/**
+ * An ImageView that maintains a square aspect ratio by setting its height
+ * to be the same as its width.
+ */
+public class SquareImageView extends AppCompatImageView {
+
+    public SquareImageView(Context context) {
+        super(context);
+    }
+
+    public SquareImageView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public SquareImageView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        // passes the width measurement specification
+        // for both the width and the height, forcing a square aspect ratio.
+        super.onMeasure(widthMeasureSpec, widthMeasureSpec);
+    }
+}

--- a/LotteryPatentPending/app/src/main/res/layout/admin_activity_main.xml
+++ b/LotteryPatentPending/app/src/main/res/layout/admin_activity_main.xml
@@ -45,7 +45,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:backgroundTint="@color/white_grey"
-            android:text="Images"
+            android:text="Browse Images"
             android:textColor="@color/black"
             android:textSize="18sp" />
 

--- a/LotteryPatentPending/app/src/main/res/layout/admin_fragment_images.xml
+++ b/LotteryPatentPending/app/src/main/res/layout/admin_fragment_images.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/admin_images_root"
+    tools:context=".AdminImagesFragment">
+
+    <!-- RecyclerView to display the grid of images -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/imagesRecyclerView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:padding="4dp"
+        android:clipToPadding="false"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <!-- Progress bar for  loading if necessary -->
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:visibility="gone" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/LotteryPatentPending/app/src/main/res/layout/admin_image_item.xml
+++ b/LotteryPatentPending/app/src/main/res/layout/admin_image_item.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="2dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- SquareImageView helps maintain a uniform grid -->
+        <com.example.lotterypatentpending.helpers.SquareImageView
+            android:id="@+id/imageView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:scaleType="centerCrop" />
+
+        <!-- TextView to show the event name below the image -->
+        <TextView
+            android:id="@+id/eventNameTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Event Name"
+            android:padding="8dp"
+            android:textColor="@android:color/black"
+            android:maxLines="1"
+            android:ellipsize="end" />
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/LotteryPatentPending/app/src/main/res/layout/dialog_image_viewer.xml
+++ b/LotteryPatentPending/app/src/main/res/layout/dialog_image_viewer.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <ImageView
+        android:id="@+id/fullImageView"
+        android:layout_width="wrap_content"
+        android_layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:contentDescription="Full-size event poster"
+        android:scaleType="fitCenter" />
+
+</LinearLayout>


### PR DESCRIPTION
Added functionality for the 'Browse Images' in admin menu.

This allows admin to see all images uploaded by organizers, and delete them via long click if desired (set image decoding to Null)